### PR TITLE
Change default event level to VERBOSE (5)

### DIFF
--- a/win_etw_macros/src/lib.rs
+++ b/win_etw_macros/src/lib.rs
@@ -1112,7 +1112,7 @@ fn parse_event_attributes(
     method_ident: &Ident,
     input_method_attrs: &[syn::Attribute],
 ) -> EventAttributes {
-    let mut level: Expr = parse_quote!(::win_etw_provider::Level::INFO);
+    let mut level: Expr = parse_quote!(::win_etw_provider::Level::VERBOSE);
     let mut opcode: Expr = parse_quote!(0);
     let mut task: Expr = parse_quote!(0);
 
@@ -1148,7 +1148,7 @@ fn parse_event_attributes(
                                                 "verbose" => quote!(VERBOSE),
                                                 _ => {
                                                     errors.push(Error::new_spanned(item, "The value specified for 'level' is not a valid string."));
-                                                    quote!(INFO)
+                                                    quote!(VERBOSE)
                                                 }
                                             };
                                             level = parse_quote!(::win_etw_provider::Level::#level_ident);

--- a/win_etw_provider/src/lib.rs
+++ b/win_etw_provider/src/lib.rs
@@ -44,7 +44,7 @@ pub enum Error {
 pub struct EventOptions {
     /// Overrides the level of the event, if present. Each event method has a default, which can be
     /// specified using (for example) `#[event(level = "warn")]`. If the event declaration does not
-    /// specify a level, then the level will be `Level::INFO`.
+    /// specify a level, then the level will be `Level::VERBOSE`.
     pub level: Option<win_etw_metadata::Level>,
 
     /// Specifies the activity ID of this event.


### PR DESCRIPTION
This changes the default event level if none is specified from INFO (4)
to VERBOSE (5). This matches the implementation in TraceLoggingProvider.h,
which uses VERBOSE as well.

Note: I'm not sure if there was a particular reason INFO was chosen as the default previously. Don't think this is an absolutely necessary change, but seems better to align with other tracelogging implementations.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>