### PR TITLE
Set groupid when setting provider traits

### DIFF
--- a/win_etw_macros/Cargo.toml
+++ b/win_etw_macros/Cargo.toml
@@ -18,4 +18,4 @@ proc-macro2 = "^1.0"
 syn = { version = "^1.0", features = ["full", "extra-traits"] }
 quote = "^1.0"
 win_etw_metadata = { version = "^0.1.1", path = "../win_etw_metadata" }
-uuid = { version = "^0.8" }
+uuid = { version = "^1.3" }

--- a/win_etw_macros/src/lib.rs
+++ b/win_etw_macros/src/lib.rs
@@ -680,18 +680,7 @@ fn create_register_provider_traits(
         traits_bytes.push(0); // reserve space for TraitSize (u16)
         traits_bytes.push(0);
         traits_bytes.push(ETW_PROVIDER_TRAIT_TYPE_GROUP);
-
-        let (data1, data2, data3, data4) = provider_group_guid.to_fields_le();
-        traits_bytes.push(((data1 & 0xff000000) >> 24) as u8);
-        traits_bytes.push(((data1 & 0x00ff0000) >> 16) as u8);
-        traits_bytes.push(((data1 & 0x0000ff00) >> 8) as u8);
-        traits_bytes.push(((data1 & 0x000000ff) >> 0) as u8);
-        traits_bytes.push(((data2 & 0xff00) >> 8) as u8);
-        traits_bytes.push(((data2 & 0x00ff) >> 0) as u8);
-        traits_bytes.push(((data3 & 0xff00) >> 8) as u8);
-        traits_bytes.push(((data3 & 0x00ff) >> 0) as u8);
-        traits_bytes.extend_from_slice(data4);
-
+        traits_bytes.extend_from_slice(&provider_group_guid.to_bytes_le());
         let provider_guid_trait_len = traits_bytes.len() - provider_guid_trait_offset;
         // Set TraitSize (u16)
         traits_bytes[provider_guid_trait_offset] = provider_guid_trait_len as u8;


### PR DESCRIPTION
This PR addresses an issue where the `provider_group_guid` is not being added to the provider traits during registration.

### Causes

Both `register_provider_metadata` and `set_provider_traits` are being called, each with a different trait buffer.  These are both backed by `EventSetInformation`, which can only be called once because subsequent calls will fail ([documentation](https://learn.microsoft.com/en-us/windows/win32/etw/provider-traits)).  This failure is normally not surfaced because the error is ignored in `create_register_provider_traits`.


The trait buffer passed to set the provider group is not writing the bytes as fields as expected by `EventSetInformation`.

The trait buffer is being aligned, but it appears it is not needed and will cause `EventSetInformation` to fail depending on provider name length.

### Changes

Remove the `register_provider_metadata` call so that `set_provider_traits` will succeed.

Remove the trait buffer alignment calls and write the GUID as fields.