### PR TITLE
Fix provider name macro not being passed onto provider traits

### DIFF
--- a/win_etw_macros/src/lib.rs
+++ b/win_etw_macros/src/lib.rs
@@ -599,7 +599,7 @@ fn trace_logging_events_core(attr: TokenStream, item_tokens: TokenStream) -> Tok
 
     // Build a code fragment that registers the provider traits.
     let register_traits: TokenStream = create_register_provider_traits(
-        &provider_ident_string,
+        &provider_name,
         provider_attrs.provider_group_guid.as_ref(),
     );
 


### PR DESCRIPTION
Currently, the name of the trait definition is always the one emitted as the provider in the final ETW event, even if the 'name' macro is provided #[trace_logging_provider(name = "MyCompany.MyComponent")].

Change the provider traits to use provider_name, which can take the macro into account, rather than provider_ident_string, which is always the name of the trait definition.