### PR TITLE
Update for publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+
+/.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+resolver = "2"
+
 members = [
     "examples/hello_world",
     "win_etw_logger",

--- a/win_etw_logger/Cargo.toml
+++ b/win_etw_logger/Cargo.toml
@@ -12,7 +12,7 @@ readme = "../README.md"
 
 [dependencies]
 log = { version = "^0.4", features = ["std"] }
-win_etw_provider = { version = "0.1.7", path = "../win_etw_provider" }
+win_etw_provider = { version = "0.1.9", path = "../win_etw_provider" }
 win_etw_macros = { version = "0.1.7", path = "../win_etw_macros" }
 win_etw_metadata = { version = "0.1.2", path = "../win_etw_metadata" }
 winapi = { version = "^0.3.8" }

--- a/win_etw_provider/Cargo.toml
+++ b/win_etw_provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "win_etw_provider"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
 edition = "2018"
 description = "Enables apps to report events to Event Tracing for Windows (ETW)."

--- a/win_etw_tracing/Cargo.toml
+++ b/win_etw_tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "win_etw_tracing"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "Provides a backend for the `tracing` crate that logs events to ETW (Event Tracing for Windows)."
@@ -16,7 +16,7 @@ tracing = "0.1"
 tracing-log = { version = "0.1", optional = true, default-features = false, features = ["log-tracer", "std"] }
 tracing-subscriber = "0.3.7"
 win_etw_metadata = { path = "../win_etw_metadata", version = "0.1.2" }
-win_etw_provider = { path = "../win_etw_provider", version = "0.1.7" }
+win_etw_provider = { path = "../win_etw_provider", version = "0.1.9" }
 
 [dev-dependencies]
 anyhow = "1"


### PR DESCRIPTION
This bumps the versions for `win_etw_provider` and `win_etw_tracing`, in preparation for publishing.

* Also added a `.gitignore` entry for `.vscode`.
* Also added an explicit resolver opt-in for the virtual manifest / workspace.
* 