### PR TITLE
Add no_std feature and make it default for win_etw_provider

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        rust: [1.68.0, stable]
+        rust: [1.77.0, stable]
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 win_etw_macros = { path = "../../win_etw_macros" }
-win_etw_provider = { path = "../../win_etw_provider" }
+win_etw_provider = { path = "../../win_etw_provider", features = ["std"] }
 widestring = "^1.0"
 winapi = { version = "^0.3.8", features = ["ntstatus"] }
 

--- a/win_etw_provider/Cargo.toml
+++ b/win_etw_provider/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-widestring = "^1.0"
+widestring = {version = "^1.0", default-features = false, features = ["alloc"]}
 zerocopy = { version = "0.7.32", features = ["derive"] }
 win_etw_metadata = { version = "^0.1.2", path = "../win_etw_metadata" }
 uuid = {version = "1", optional = true}
@@ -27,5 +27,6 @@ uuid = "1"
 [features]
 std = []
 default = ["std"]
+no_std = []
 # dev is used only for development
 dev = []

--- a/win_etw_provider/Cargo.toml
+++ b/win_etw_provider/Cargo.toml
@@ -26,7 +26,7 @@ uuid = "1"
 
 [features]
 std = []
-default = ["std"]
+default = ["no_std"]
 no_std = []
 # dev is used only for development
 dev = []

--- a/win_etw_provider/Cargo.toml
+++ b/win_etw_provider/Cargo.toml
@@ -7,6 +7,7 @@ description = "Enables apps to report events to Event Tracing for Windows (ETW).
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/microsoft/rust_win_etw"
 readme = "../README.md"
+rust-version = "1.77"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/win_etw_provider/src/lib.rs
+++ b/win_etw_provider/src/lib.rs
@@ -6,6 +6,9 @@
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(not(windows), allow(unused))]
 
+#[cfg(feature = "no_std")]
+extern crate alloc;
+
 mod guid;
 mod provider;
 

--- a/win_etw_provider/src/lib.rs
+++ b/win_etw_provider/src/lib.rs
@@ -6,7 +6,6 @@
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(not(windows), allow(unused))]
 
-#[cfg(feature = "no_std")]
 extern crate alloc;
 
 mod guid;

--- a/win_etw_provider/src/provider.rs
+++ b/win_etw_provider/src/provider.rs
@@ -1,7 +1,6 @@
 use crate::guid::GUID;
 use crate::Level;
 use crate::{Error, EventDataDescriptor};
-#[cfg(feature = "no_std")]
 use alloc::boxed::Box;
 use core::convert::TryFrom;
 use core::pin::Pin;

--- a/win_etw_provider/src/provider.rs
+++ b/win_etw_provider/src/provider.rs
@@ -1,6 +1,8 @@
 use crate::guid::GUID;
 use crate::Level;
 use crate::{Error, EventDataDescriptor};
+#[cfg(feature = "no_std")]
+use alloc::boxed::Box;
 use core::convert::TryFrom;
 use core::pin::Pin;
 use core::ptr::null;

--- a/win_etw_provider/src/types.rs
+++ b/win_etw_provider/src/types.rs
@@ -30,9 +30,8 @@ pub struct SocketAddrV4 {
     pub zero: [u8; 8],
 }
 
-#[cfg(feature = "std")]
-impl From<&std::net::SocketAddrV4> for SocketAddrV4 {
-    fn from(value: &std::net::SocketAddrV4) -> Self {
+impl From<&core::net::SocketAddrV4> for SocketAddrV4 {
+    fn from(value: &core::net::SocketAddrV4) -> Self {
         let port = value.port();
         Self {
             family: AF_INET,
@@ -65,9 +64,8 @@ pub struct SocketAddrV6 {
     pub scope_id: [u8; 4],
 }
 
-#[cfg(feature = "std")]
-impl From<&std::net::SocketAddrV6> for SocketAddrV6 {
-    fn from(value: &std::net::SocketAddrV6) -> Self {
+impl From<&core::net::SocketAddrV6> for SocketAddrV6 {
+    fn from(value: &core::net::SocketAddrV6) -> Self {
         Self {
             family: AF_INET6,
             port: value.port().to_be_bytes(),


### PR DESCRIPTION
This crate is very close to being no_std as it is.  At this point the only portion that cannot be done in no_std is, appropriately enough, the std_support module.  

This change adds a no_std feature, makes it default, and makes minor tweaks to maximize no_std compatibility (using widestring's "alloc" feature, updating the IP structs to their core versions, adding a few references to the alloc crate.)

