### PR TITLE
Remove unnecessary enablement of tracing-subscriber ansi feature

### DIFF
--- a/win_etw_tracing/Cargo.toml
+++ b/win_etw_tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "win_etw_tracing"
-version = "0.2.0"
+version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "Provides a backend for the `tracing` crate that logs events to ETW (Event Tracing for Windows)."
@@ -9,7 +9,6 @@ readme = "../README.md"
 
 [features]
 default = ["tracing-log"]
-tracing-log = ["dep:tracing-log","tracing-subscriber/tracing-log"]
 
 [dependencies]
 bytes = "1"

--- a/win_etw_tracing/Cargo.toml
+++ b/win_etw_tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "win_etw_tracing"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "Provides a backend for the `tracing` crate that logs events to ETW (Event Tracing for Windows)."
@@ -9,12 +9,13 @@ readme = "../README.md"
 
 [features]
 default = ["tracing-log"]
+tracing-log = ["dep:tracing-log","tracing-subscriber/tracing-log"]
 
 [dependencies]
 bytes = "1"
 tracing = "0.1"
 tracing-log = { version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
-tracing-subscriber = "0.3.7"
+tracing-subscriber = { version = "0.3.7", default-features = false, features = ["smallvec", "fmt", "std"] }
 win_etw_metadata = { path = "../win_etw_metadata", version = "0.1.2" }
 win_etw_provider = { path = "../win_etw_provider", version = "0.1.9" }
 


### PR DESCRIPTION
Partially fixes #40

I'm not sure if this is considered a breaking change; if so, happy to bump version to 0.2.0 instead.