### PR TITLE
Remove unnecessary dependency on w32-error

### DIFF
--- a/win_etw_provider/Cargo.toml
+++ b/win_etw_provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "win_etw_provider"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
 edition = "2018"
 description = "Enables apps to report events to Event Tracing for Windows (ETW)."
@@ -19,7 +19,6 @@ uuid = {version = "1", optional = true}
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "^0.3", features = ["evntprov", "winerror", "evntrace"] }
-w32-error = "^1.0"
 
 [dev-dependencies]
 atomic_lazy = { git = "https://github.com/sivadeilra/atomic_lazy" }


### PR DESCRIPTION
While there's nothing obviously wrong with it, we don't seem to use it in any way, and this is one of the only two consumers of the library based on crates.io.

Since we don't use it, remove it.

Another step towards #40 