### PR TITLE
Replace winapi

### DIFF
--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -12,7 +12,12 @@ edition = "2018"
 win_etw_macros = { path = "../../win_etw_macros" }
 win_etw_provider = { path = "../../win_etw_provider", features = ["std"] }
 widestring = "^1.0"
-winapi = { version = "^0.3.8", features = ["ntstatus"] }
+
+[dependencies.windows]
+version = "0.58.0"
+features = [
+    "Win32_Foundation",
+]
 
 [features]
 default = []

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -4,7 +4,7 @@
 name = "hello_world"
 version = "0.1.1"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
         pub use windows::Win32::Foundation::{STATUS_DEVICE_REQUIRES_CLEANING, DXGI_DDI_ERR_WASSTILLDRAWING, ERROR_OUT_OF_PAPER};
 
         hello_provider.arg_hresult(None, DXGI_DDI_ERR_WASSTILLDRAWING);
-        hello_provider.arg_ntstatus(None, STATUS_DEVICE_REQUIRES_CLEANING as u32);
+        hello_provider.arg_ntstatus(None, STATUS_DEVICE_REQUIRES_CLEANING.0);
         hello_provider.arg_win32error(None, ERROR_OUT_OF_PAPER);
     }
 

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -48,12 +48,11 @@ fn main() {
 
     #[cfg(target_os = "windows")]
     {
-        pub use winapi::shared::ntstatus;
-        pub use winapi::shared::winerror;
+        pub use windows::Win32::Foundation::{STATUS_DEVICE_REQUIRES_CLEANING, DXGI_DDI_ERR_WASSTILLDRAWING, ERROR_OUT_OF_PAPER};
 
-        hello_provider.arg_hresult(None, winerror::DXGI_DDI_ERR_WASSTILLDRAWING);
-        hello_provider.arg_ntstatus(None, ntstatus::STATUS_DEVICE_REQUIRES_CLEANING as u32);
-        hello_provider.arg_win32error(None, winerror::ERROR_OUT_OF_PAPER);
+        hello_provider.arg_hresult(None, DXGI_DDI_ERR_WASSTILLDRAWING);
+        hello_provider.arg_ntstatus(None, STATUS_DEVICE_REQUIRES_CLEANING as u32);
+        hello_provider.arg_win32error(None, ERROR_OUT_OF_PAPER);
     }
 
     let args = std::env::args().collect::<Vec<String>>();

--- a/win_etw_logger/Cargo.toml
+++ b/win_etw_logger/Cargo.toml
@@ -16,4 +16,4 @@ win_etw_provider = { version = "0.1.9", path = "../win_etw_provider" }
 win_etw_macros = { version = "0.1.7", path = "../win_etw_macros" }
 win_etw_metadata = { version = "0.1.2", path = "../win_etw_metadata" }
 windows-core = { version = "0.58.0" }
-windows = { version = "0.58.0", features = ["Win32_Foundation"] }
+windows = { version = "0.58.0", features = ["Win32_Foundation", "Win32_System_Diagnostics_Etw"] }

--- a/win_etw_logger/Cargo.toml
+++ b/win_etw_logger/Cargo.toml
@@ -2,7 +2,7 @@
 name = "win_etw_logger"
 version = "0.1.7"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
-edition = "2018"
+edition = "2021"
 description = "A Rust log provider which forwards events to Event Tracing for Windows (ETW)."
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/microsoft/rust_win_etw"
@@ -15,4 +15,5 @@ log = { version = "^0.4", features = ["std"] }
 win_etw_provider = { version = "0.1.9", path = "../win_etw_provider" }
 win_etw_macros = { version = "0.1.7", path = "../win_etw_macros" }
 win_etw_metadata = { version = "0.1.2", path = "../win_etw_metadata" }
-winapi = { version = "^0.3.8" }
+windows-core = { version = "0.58.0" }
+windows = { version = "0.58.0", features = ["Win32_Foundation"] }

--- a/win_etw_macros/Cargo.toml
+++ b/win_etw_macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "win_etw_macros"
 version = "0.1.9"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
-edition = "2018"
+edition = "2021"
 description = "Enables apps to report events to Event Tracing for Windows (ETW)."
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/microsoft/rust_win_etw"

--- a/win_etw_metadata/Cargo.toml
+++ b/win_etw_metadata/Cargo.toml
@@ -2,7 +2,7 @@
 name = "win_etw_metadata"
 version = "0.1.2"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
-edition = "2018"
+edition = "2021"
 description = "Provides metadata definitions for the win_etw_provider and win_etw_macros crates."
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/microsoft/rust_win_etw"

--- a/win_etw_provider/Cargo.toml
+++ b/win_etw_provider/Cargo.toml
@@ -19,7 +19,7 @@ uuid = {version = "1", optional = true}
 
 [target.'cfg(windows)'.dependencies]
 windows-core = { version = "0.58.0" }
-windows = { version = "0.58.0", features = ["Win32_Foundation"] }
+windows = { version = "0.58.0", features = ["Win32_Foundation", "Win32_System_Diagnostics_Etw"] }
 
 
 

--- a/win_etw_provider/Cargo.toml
+++ b/win_etw_provider/Cargo.toml
@@ -2,7 +2,7 @@
 name = "win_etw_provider"
 version = "0.1.10"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
-edition = "2018"
+edition = "2021"
 description = "Enables apps to report events to Event Tracing for Windows (ETW)."
 license = "Apache-2.0 OR MIT"
 homepage = "https://github.com/microsoft/rust_win_etw"
@@ -18,8 +18,10 @@ win_etw_metadata = { version = "^0.1.2", path = "../win_etw_metadata" }
 uuid = {version = "1", optional = true}
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "^0.3", features = ["evntprov", "winerror", "evntrace"] }
-w32-error = "^1.0"
+windows-core = { version = "0.58.0" }
+windows = { version = "0.58.0", features = ["Win32_Foundation"] }
+
+
 
 [dev-dependencies]
 atomic_lazy = { git = "https://github.com/sivadeilra/atomic_lazy" }

--- a/win_etw_provider/src/guid.rs
+++ b/win_etw_provider/src/guid.rs
@@ -46,6 +46,7 @@ macro_rules! guid {
 /// an equivalent type from other crates in order to minimize its dependencies. `GUID` has a well-
 /// defined byte representation, so converting between different implementations of `GUID` is
 /// not a problem.
+/// TODO: we're depending on windows-core anyway, can we drop this?
 #[repr(C)]
 #[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, AsBytes, FromBytes, FromZeroes)]
 pub struct GUID {
@@ -86,13 +87,13 @@ impl core::fmt::Debug for GUID {
 }
 
 #[cfg(target_os = "windows")]
-impl From<winapi::shared::guiddef::GUID> for GUID {
-    fn from(value: winapi::shared::guiddef::GUID) -> Self {
+impl From<windows_core::GUID> for GUID {
+    fn from(value: windows_core::GUID) -> Self {
         Self {
-            data1: value.Data1,
-            data2: value.Data2,
-            data3: value.Data3,
-            data4: value.Data4,
+            data1: value.data1,
+            data2: value.data2,
+            data3: value.data3,
+            data4: value.data4,
         }
     }
 }

--- a/win_etw_provider/src/provider.rs
+++ b/win_etw_provider/src/provider.rs
@@ -146,7 +146,7 @@ impl Provider for EtwProvider {
                     0,                       // flags
                     Some(activity_id_ptr),         // activity id
                     Some(related_activity_id_ptr), // related activity id
-                    Some(data)
+                    Some(std::mem::transmute(data)) // TODO: assert size and aligment adds up
                 );
                 if error != 0 {
                     write_failed(error)

--- a/win_etw_provider/src/provider.rs
+++ b/win_etw_provider/src/provider.rs
@@ -126,11 +126,11 @@ impl Provider for EtwProvider {
 
                 if let Some(options) = options {
                     if let Some(id) = options.activity_id.as_ref() {
-                        activity_id_ptr = id as *const GUID as *const winapi::shared::guiddef::GUID;
+                        activity_id_ptr = id as *const GUID as *const windows_core::GUID;
                     }
                     if let Some(id) = options.related_activity_id.as_ref() {
                         related_activity_id_ptr =
-                            id as *const GUID as *const winapi::shared::guiddef::GUID;
+                            id as *const GUID as *const windows_core::GUID;
                     }
                     if let Some(level) = options.level {
                         event_descriptor.Level = level.0;
@@ -216,7 +216,7 @@ mod win_support {
 
     /// See [PENABLECALLBACK](https://docs.microsoft.com/en-us/windows/win32/api/evntprov/nc-evntprov-penablecallback).
     pub(crate) unsafe extern "system" fn enable_callback(
-        _source_id: *const winapi::shared::guiddef::GUID,
+        _source_id: *const windows_core::GUID,
         is_enabled_code: u32,
         level: u8,
         _match_any_keyword: u64,
@@ -282,7 +282,7 @@ mod win_support {
 
     pub fn new_activity_id() -> Result<GUID, Error> {
         unsafe {
-            let mut guid: winapi::shared::guiddef::GUID = core::mem::zeroed();
+            let mut guid: windows_core::GUID = core::mem::zeroed();
             let error = evntprov::EventActivityIdControl(
                 evntprov::EVENT_ACTIVITY_CTRL_CREATE_ID,
                 &mut guid,
@@ -310,7 +310,7 @@ impl EtwProvider {
                 let mut handle: evntprov::REGHANDLE = 0;
                 let stable_ptr: &mut StableProviderData = &mut stable;
                 let error = evntprov::EventRegister(
-                    provider_id as *const _ as *const winapi::shared::guiddef::GUID,
+                    provider_id as *const _ as *const windows_core::GUID,
                     Some(enable_callback),
                     stable_ptr as *mut StableProviderData as *mut winapi::ctypes::c_void,
                     &mut handle,
@@ -437,7 +437,7 @@ pub fn with_activity<F: FnOnce() -> R, R>(f: F) -> R {
         unsafe {
             let result = evntprov::EventActivityIdControl(
                 evntprov::EVENT_ACTIVITY_CTRL_CREATE_SET_ID,
-                &mut previous_activity_id as *mut _ as *mut winapi::shared::guiddef::GUID,
+                &mut previous_activity_id as *mut _ as *mut windows_core::GUID,
             );
             if result == winerror::ERROR_SUCCESS {
                 restore.previous_activity_id = Some(previous_activity_id);
@@ -471,7 +471,7 @@ impl Drop for RestoreActivityHolder {
                 if let Some(previous_activity_id) = self.previous_activity_id.as_ref() {
                     evntprov::EventActivityIdControl(
                         evntprov::EVENT_ACTIVITY_CTRL_SET_ID,
-                        previous_activity_id as *const GUID as *const winapi::shared::guiddef::GUID
+                        previous_activity_id as *const GUID as *const windows_core::GUID
                             as *mut _,
                     );
                 }


### PR DESCRIPTION
Fully closes #40 

Currently, examples don't pass because various methods expect primitive types instead of the nice newtype wrappers.
Other than that, I think it's feature complete.

Also bump to 2021 editions while we're here.

likely need to bump minor version at a minimum as this is probably a breaking change.
