### PR TITLE
Fix tracing-etw link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This framework allows applications to log schematized events, rather than textua
 ETW analysis tools can reliably identify fields within your events, and treat them as
 strongly-typed data, rather than text strings.
 
-To use [tracing](https://tracing.rs) with ETW, see [tracing-etw](./win_etw_tracing/).
+To use [tracing](https://tracing.rs) with ETW, see [tracing-etw](https://github.com/microsoft/tracing-etw).
 
 ## How to create and use an event provider
 


### PR DESCRIPTION
Revert #26, which broke the link to tracing-etw.

tracing-etw is the tracing subscriber crate maintained by the ETW team at Microsoft.