### PR TITLE
chore: Use the repository instead of the homepage field in Cargo.toml

### DIFF
--- a/win_etw_logger/Cargo.toml
+++ b/win_etw_logger/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Arlie Davis <ardavis@microsoft.com>"]
 edition = "2018"
 description = "A Rust log provider which forwards events to Event Tracing for Windows (ETW)."
 license = "Apache-2.0 OR MIT"
-homepage = "https://github.com/microsoft/rust_win_etw"
+repository = "https://github.com/microsoft/rust_win_etw"
 readme = "../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/win_etw_macros/Cargo.toml
+++ b/win_etw_macros/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Arlie Davis <ardavis@microsoft.com>"]
 edition = "2018"
 description = "Enables apps to report events to Event Tracing for Windows (ETW)."
 license = "Apache-2.0 OR MIT"
-homepage = "https://github.com/microsoft/rust_win_etw"
+repository = "https://github.com/microsoft/rust_win_etw"
 readme = "../README.md"
 
 [lib]

--- a/win_etw_metadata/Cargo.toml
+++ b/win_etw_metadata/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Arlie Davis <ardavis@microsoft.com>"]
 edition = "2018"
 description = "Provides metadata definitions for the win_etw_provider and win_etw_macros crates."
 license = "Apache-2.0 OR MIT"
-homepage = "https://github.com/microsoft/rust_win_etw"
+repository = "https://github.com/microsoft/rust_win_etw"
 readme = "../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/win_etw_provider/Cargo.toml
+++ b/win_etw_provider/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Arlie Davis <ardavis@microsoft.com>"]
 edition = "2018"
 description = "Enables apps to report events to Event Tracing for Windows (ETW)."
 license = "Apache-2.0 OR MIT"
-homepage = "https://github.com/microsoft/rust_win_etw"
+repository = "https://github.com/microsoft/rust_win_etw"
 readme = "../README.md"
 rust-version = "1.77"
 

--- a/win_etw_tracing/Cargo.toml
+++ b/win_etw_tracing/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.2"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = "Provides a backend for the `tracing` crate that logs events to ETW (Event Tracing for Windows)."
-homepage = "https://github.com/microsoft/rust_win_etw"
+repository = "https://github.com/microsoft/rust_win_etw"
 readme = "../README.md"
 
 [features]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.